### PR TITLE
Fix profile avatar deletion message

### DIFF
--- a/backend/app/Http/Controllers/Api/ProfileController.php
+++ b/backend/app/Http/Controllers/Api/ProfileController.php
@@ -103,7 +103,7 @@ class ProfileController extends Controller
             Storage::disk('private')->delete($path);
         }
 
-        return response()->json(['message' => 'Avatar updated']);
+        return response()->json(['message' => 'Avatar deleted']);
     }
 
     private function getAvatarPath(string $type, int $id): string


### PR DESCRIPTION
## Summary
- update deleteAvatar success message in ProfileController

## Testing
- `node -v`
- ❌ `composer install --no-interaction` *(fails: composer not installed)*
- ❌ `backend/vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68480bd863a883239e5e22a84d3897b7